### PR TITLE
feat: switch to offcanvas navbar

### DIFF
--- a/recipe_app/static/style.css
+++ b/recipe_app/static/style.css
@@ -184,4 +184,24 @@ body {
   padding: 1rem 0.75rem;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
+.navbar-nav .nav-link {
+  display: flex;
+  align-items: center;
+}
+
+.navbar-nav .nav-link .nav-text {
+  display: none;
+}
+
+@media (min-width: 992px) {
+  .navbar-nav .nav-link .nav-text {
+    display: inline;
+    margin-left: 0.5rem;
+  }
+}
+
 /*# sourceMappingURL=style.css.map */

--- a/recipe_app/templates/base.html
+++ b/recipe_app/templates/base.html
@@ -528,15 +528,20 @@
     <!-- End Google Tag Manager (noscript) -->
     
     <header>
-      <nav class="navbar navbar-expand-lg navbar-light sticky-top">
-        <div class="container">
+      <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
+        <div class="container-fluid">
           <a class="navbar-brand" href="{{ url_for('main.dashboard') if current_user.is_authenticated else url_for('main.index') }}">
-            <img src="{{ url_for('static', filename='HomeGrubHub.png') }}" alt="HomeGrubHub" class="navbar-logo">HomeGrubHub
+            <img src="{{ url_for('static', filename='HomeGrubHub.png') }}" alt="HomeGrubHub" class="navbar-logo">
           </a>
-          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar" aria-controls="offcanvasNavbar">
             <span class="navbar-toggler-icon"></span>
           </button>
-          <div class="collapse navbar-collapse" id="navbarNav">
+          <div class="offcanvas offcanvas-start offcanvas-lg" tabindex="-1" id="offcanvasNavbar" aria-labelledby="offcanvasNavbarLabel">
+            <div class="offcanvas-header">
+              <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Menu</h5>
+              <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+            </div>
+            <div class="offcanvas-body">
             {% if current_user.is_authenticated %}
             <ul class="navbar-nav me-auto">
               <!-- Core Navigation -->
@@ -855,6 +860,7 @@
               </li>
               {% endif %}
             </ul>
+            </div>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
## Summary
- replace header navigation with Bootstrap 5 offcanvas for mobile-first sticky layout
- hide menu text on small screens to present compact icon-only nav
- enable smooth scrolling and flex alignment for nav icons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7f109e9808329889df8e95f90e828