### PR TITLE
Add recipe card styles and lazy image placeholders

### DIFF
--- a/recipe_app/static/scss/_components.scss
+++ b/recipe_app/static/scss/_components.scss
@@ -1,4 +1,5 @@
 @use 'variables' as *;
+@use 'components/recipe-card';
 
 .card {
   border: none;

--- a/recipe_app/static/scss/components/_recipe-card.scss
+++ b/recipe_app/static/scss/components/_recipe-card.scss
@@ -1,0 +1,37 @@
+@use '../variables' as *;
+
+.recipe-card {
+  border-radius: $radius-md;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  }
+
+  .card-img-wrapper {
+    position: relative;
+  }
+
+  .image-placeholder {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 37%, #f0f0f0 63%);
+    background-size: 400% 100%;
+    animation: placeholderShimmer 1.4s ease infinite;
+  }
+}
+
+@keyframes placeholderShimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}

--- a/recipe_app/static/style.css
+++ b/recipe_app/static/style.css
@@ -205,3 +205,39 @@ html {
 }
 
 /*# sourceMappingURL=style.css.map */
+
+.recipe-card {
+    border-radius: 15px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    overflow: hidden;
+}
+
+.recipe-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+}
+
+.recipe-card .card-img-wrapper {
+    position: relative;
+}
+
+.image-placeholder {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 37%, #f0f0f0 63%);
+    background-size: 400% 100%;
+    animation: placeholderShimmer 1.4s ease infinite;
+}
+
+@keyframes placeholderShimmer {
+    0% {
+        background-position: 100% 0;
+    }
+    100% {
+        background-position: -100% 0;
+    }
+}

--- a/recipe_app/templates/all_recipes.html
+++ b/recipe_app/templates/all_recipes.html
@@ -47,21 +47,45 @@
         <div class="card-img-wrapper" style="height: 200px; overflow: hidden;">
           {% if recipe.image_file %}
           {% if recipe.image_file.startswith('imported_') %}
-          <img src="{{ url_for('static', filename='uploads/imported_' + recipe.image_file[9:]) }}" 
-               class="card-img-top w-100 h-100" style="object-fit: cover;" 
-               alt="{{ recipe.title }}">
+          <div class="image-placeholder"></div>
+          <img src="{{ url_for('static', filename='uploads/imported_' + recipe.image_file[9:]) }}"
+               class="card-img-top w-100 h-100 d-none" style="object-fit: cover;"
+               loading="lazy" alt="{{ recipe.title }}"
+               onload="this.classList.remove('d-none'); this.previousElementSibling.remove();">
           {% else %}
-          <img src="{{ url_for('static', filename='uploads/' + recipe.image_file) }}" 
-               class="card-img-top w-100 h-100" style="object-fit: cover;" 
-               alt="{{ recipe.title }}">
+          <div class="image-placeholder"></div>
+          <img src="{{ url_for('static', filename='uploads/' + recipe.image_file) }}"
+               class="card-img-top w-100 h-100 d-none" style="object-fit: cover;"
+               loading="lazy" alt="{{ recipe.title }}"
+               onload="this.classList.remove('d-none'); this.previousElementSibling.remove();">
           {% endif %}
           {% else %}
           <div class="card-img-top w-100 h-100 bg-light d-flex align-items-center justify-content-center">
             <i class="fas fa-utensils fa-3x text-muted"></i>
           </div>
           {% endif %}
-          
-          <!-- Quick Info Overlay -->
+
+          <!-- Badges Overlay -->
+          <div class="position-absolute top-0 start-0 p-2 d-flex flex-column gap-1">
+            {% if recipe.cook_time %}
+            <span class="badge bg-dark bg-opacity-75">
+              <i class="fas fa-clock me-1"></i>{{ recipe.cook_time }}m
+            </span>
+            {% endif %}
+            {% if recipe.difficulty %}
+            <span class="badge bg-info bg-opacity-75">
+              <i class="fas fa-signal me-1"></i>{{ recipe.difficulty }}
+            </span>
+            {% endif %}
+            {% set avg_rating = recipe.get_average_rating() %}
+            {% if avg_rating %}
+            <span class="badge bg-warning text-dark">
+              <i class="fas fa-star me-1"></i>{{ avg_rating|round(1) }}
+            </span>
+            {% endif %}
+          </div>
+
+          <!-- Country Badge -->
           <div class="position-absolute top-0 end-0 p-2">
             {% if recipe.country %}
             <span class="badge bg-primary">
@@ -69,16 +93,6 @@
             </span>
             {% endif %}
           </div>
-          
-          {% if recipe.prep_time or recipe.cook_time %}
-          <div class="position-absolute bottom-0 start-0 p-2">
-            {% if recipe.prep_time %}
-            <span class="badge bg-dark bg-opacity-75">
-              <i class="fas fa-clock me-1"></i>{{ recipe.prep_time }}min
-            </span>
-            {% endif %}
-          </div>
-          {% endif %}
         </div>
 
         <!-- Recipe Content -->

--- a/recipe_app/templates/community/recipes.html
+++ b/recipe_app/templates/community/recipes.html
@@ -254,8 +254,24 @@
         <div class="col-lg-3 col-md-4 col-sm-6 mb-4">
             <div class="card recipe-card h-100">
                 {% if recipe.photos %}
-                    <img src="{{ url_for('static', filename='uploads/photos/' + recipe.photos[0].filename) }}" 
-                         class="recipe-image" alt="{{ recipe.title }}">
+                    <div class="card-img-wrapper position-relative" style="height: 200px;">
+                        <div class="image-placeholder"></div>
+                        <img src="{{ url_for('static', filename='uploads/photos/' + recipe.photos[0].filename) }}"
+                             class="recipe-image d-none w-100 h-100" alt="{{ recipe.title }}" loading="lazy"
+                             onload="this.classList.remove('d-none'); this.previousElementSibling.remove();">
+                        <div class="position-absolute top-0 start-0 p-2 d-flex flex-column gap-1">
+                            {% if recipe.cook_time %}
+                            <span class="badge bg-dark bg-opacity-75"><i class="fas fa-clock me-1"></i>{{ recipe.cook_time }}m</span>
+                            {% endif %}
+                            {% if recipe.difficulty %}
+                            <span class="badge bg-info bg-opacity-75"><i class="fas fa-signal me-1"></i>{{ recipe.difficulty }}</span>
+                            {% endif %}
+                            {% set avg_rating = recipe.get_average_rating() %}
+                            {% if avg_rating %}
+                            <span class="badge bg-warning text-dark"><i class="fas fa-star me-1"></i>{{ avg_rating|round(1) }}</span>
+                            {% endif %}
+                        </div>
+                    </div>
                 {% else %}
                     <div class="recipe-image d-flex align-items-center justify-content-center bg-light">
                         <i class="fas fa-utensils text-muted" style="font-size: 2rem;"></i>

--- a/recipe_app/templates/family/recipe_collection.html
+++ b/recipe_app/templates/family/recipe_collection.html
@@ -148,13 +148,14 @@
                                 <div class="card h-100 recipe-card">
                                     <div class="recipe-image-container position-relative">
                                         {% if collection_item.recipe.image_url %}
-                                            <img src="{{ collection_item.recipe.image_url }}" class="card-img-top recipe-image" alt="{{ collection_item.recipe.name }}">
+                                            <div class="image-placeholder"></div>
+                                            <img src="{{ collection_item.recipe.image_url }}" class="card-img-top recipe-image d-none" alt="{{ collection_item.recipe.name }}" loading="lazy" onload="this.classList.remove('d-none'); this.previousElementSibling.remove();">
                                         {% else %}
                                             <div class="recipe-placeholder d-flex align-items-center justify-content-center">
                                                 <i class="fas fa-utensils fa-3x text-muted"></i>
                                             </div>
                                         {% endif %}
-                                        
+
                                         <!-- Recipe Status Badges -->
                                         <div class="position-absolute top-0 start-0 p-2">
                                             {% if collection_item.is_family_favorite %}
@@ -162,36 +163,32 @@
                                                     <i class="fas fa-heart me-1"></i>Favorite
                                                 </span>
                                             {% endif %}
+        
                                             {% if collection_item.times_made > 5 %}
                                                 <span class="badge bg-success">
                                                     <i class="fas fa-trophy me-1"></i>Popular
                                                 </span>
                                             {% endif %}
                                         </div>
-                                        
-                                        <!-- Rating Display -->
+
+                                        <!-- Info Badges -->
+                                        <div class="position-absolute bottom-0 start-0 p-2 d-flex flex-column gap-1">
+                                            {% if collection_item.recipe.cook_time %}
+                                            <span class="badge bg-dark bg-opacity-75"><i class="fas fa-clock me-1"></i>{{ collection_item.recipe.cook_time }}m</span>
+                                            {% endif %}
+        
+        
+                                            {% if collection_item.recipe.difficulty %}
+                                            <span class="badge bg-info bg-opacity-75"><i class="fas fa-signal me-1"></i>{{ collection_item.recipe.difficulty }}</span>
+                                            {% endif %}
+                                        </div>
+
+                                        <!-- Rating Badge -->
                                         <div class="position-absolute top-0 end-0 p-2">
-                                            <div class="bg-dark bg-opacity-75 rounded px-2 py-1">
-                                                <div class="recipe-rating text-white">
-                                                    {% set avg_rating = collection_item.get_average_rating() %}
-                                                    {% if avg_rating %}
-                                                        <span class="rating-stars">
-                                                            {% for i in range(1, 6) %}
-                                                                {% if i <= avg_rating %}
-                                                                    <i class="fas fa-star text-warning"></i>
-                                                                {% elif i - 0.5 <= avg_rating %}
-                                                                    <i class="fas fa-star-half-alt text-warning"></i>
-                                                                {% else %}
-                                                                    <i class="far fa-star text-warning"></i>
-                                                                {% endif %}
-                                                            {% endfor %}
-                                                        </span>
-                                                        <span class="ms-1 small">{{ avg_rating|round(1) }}</span>
-                                                    {% else %}
-                                                        <span class="text-muted small">No ratings</span>
-                                                    {% endif %}
-                                                </div>
-                                            </div>
+                                            {% set avg_rating = collection_item.get_average_rating() %}
+                                            {% if avg_rating %}
+                                            <span class="badge bg-warning text-dark"><i class="fas fa-star me-1"></i>{{ avg_rating|round(1) }}</span>
+                                            {% endif %}
                                         </div>
                                     </div>
                                     

--- a/recipe_app/templates/search.html
+++ b/recipe_app/templates/search.html
@@ -127,13 +127,26 @@ Search thousands of family-friendly recipes by ingredient, cuisine, dietary need
     <div class="col-lg-4 col-md-6">
       <div class="card recipe-card h-100 border-0 shadow-sm">
         {% if recipe.image_url %}
-        <div class="card-img-container">
-          <img src="{{ recipe.image_url }}" class="card-img-top" alt="{{ recipe.title }}" 
-               style="height: 200px; object-fit: cover;">
+        <div class="card-img-container position-relative" style="height: 200px;">
+          <div class="image-placeholder"></div>
+          <img src="{{ recipe.image_url }}" class="card-img-top d-none" alt="{{ recipe.title }}"
+               style="height: 200px; object-fit: cover;" loading="lazy"
+               onload="this.classList.remove('d-none'); this.previousElementSibling.remove();">
           <div class="card-img-overlay-gradient"></div>
+          <div class="position-absolute top-0 start-0 p-2 d-flex flex-column gap-1">
+            {% if recipe.cook_time %}
+            <span class="badge bg-dark bg-opacity-75"><i class="fas fa-clock me-1"></i>{{ recipe.cook_time }}m</span>
+            {% endif %}
+            {% if recipe.difficulty %}
+            <span class="badge bg-info bg-opacity-75"><i class="fas fa-signal me-1"></i>{{ recipe.difficulty }}</span>
+            {% endif %}
+            {% if recipe.average_rating %}
+            <span class="badge bg-warning text-dark"><i class="fas fa-star me-1"></i>{{ recipe.average_rating|round(1) }}</span>
+            {% endif %}
+          </div>
         </div>
         {% else %}
-        <div class="card-img-placeholder d-flex align-items-center justify-content-center bg-light" 
+        <div class="card-img-placeholder d-flex align-items-center justify-content-center bg-light position-relative"
              style="height: 200px;">
           <i class="fas fa-utensils fa-3x text-muted"></i>
         </div>

--- a/recipe_app/templates/tag.html
+++ b/recipe_app/templates/tag.html
@@ -42,16 +42,29 @@
     <div class="col-lg-4 col-md-6">
       <div class="card recipe-card h-100 border-0 shadow-sm">
         {% if recipe.image_url %}
-        <div class="card-img-container">
-          <img src="{{ recipe.image_url }}" class="card-img-top" alt="{{ recipe.title }}" 
-               style="height: 200px; object-fit: cover;">
+        <div class="card-img-container position-relative" style="height: 200px;">
+          <div class="image-placeholder"></div>
+          <img src="{{ recipe.image_url }}" class="card-img-top d-none" alt="{{ recipe.title }}"
+               style="height: 200px; object-fit: cover;" loading="lazy"
+               onload="this.classList.remove('d-none'); this.previousElementSibling.remove();">
           <div class="card-img-overlay-gradient"></div>
+          <div class="position-absolute top-0 start-0 p-2 d-flex flex-column gap-1">
+            {% if recipe.cook_time %}
+            <span class="badge bg-dark bg-opacity-75"><i class="fas fa-clock me-1"></i>{{ recipe.cook_time }}m</span>
+            {% endif %}
+            {% if recipe.difficulty %}
+            <span class="badge bg-info bg-opacity-75"><i class="fas fa-signal me-1"></i>{{ recipe.difficulty }}</span>
+            {% endif %}
+            {% if recipe.average_rating %}
+            <span class="badge bg-warning text-dark"><i class="fas fa-star me-1"></i>{{ recipe.average_rating|round(1) }}</span>
+            {% endif %}
+          </div>
           <div class="position-absolute top-0 end-0 p-2">
             <span class="badge bg-primary">{{ tag.name }}</span>
           </div>
         </div>
         {% else %}
-        <div class="card-img-placeholder d-flex align-items-center justify-content-center bg-light position-relative" 
+        <div class="card-img-placeholder d-flex align-items-center justify-content-center bg-light position-relative"
              style="height: 200px;">
           <i class="fas fa-utensils fa-3x text-muted"></i>
           <div class="position-absolute top-0 end-0 p-2">


### PR DESCRIPTION
## Summary
- style recipe cards with rounded corners, shadows and hover animations
- lazy load recipe images with skeleton placeholders
- surface cook time, difficulty and rating badges on recipe cards

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7f5bc0b188329998718d3bfe22e95