### PR TITLE
Refactor nutrition logging scripts for modularity

### DIFF
--- a/recipe_app/static/js/nutrition-log-meal.js
+++ b/recipe_app/static/js/nutrition-log-meal.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const foodsSelect = document.getElementById('foods');
+  if (!foodsSelect) return;
+
+  const foodsData = JSON.parse(foodsSelect.dataset.foods || '[]');
+
+  foodsSelect.addEventListener('change', function() {
+    const selected = Array.from(foodsSelect.selectedOptions).map(opt => parseInt(opt.value));
+    const totals = {calories: 0, protein: 0, carbs: 0, fat: 0};
+
+    foodsData.forEach(food => {
+      if (selected.includes(food.id)) {
+        totals.calories += food.calories;
+        totals.protein += food.protein;
+        totals.carbs += food.carbs;
+        totals.fat += food.fat;
+      }
+    });
+
+    document.getElementById('totalCalories').textContent = totals.calories;
+    document.getElementById('totalProtein').textContent = totals.protein;
+    document.getElementById('totalCarbs').textContent = totals.carbs;
+    document.getElementById('totalFat').textContent = totals.fat;
+  });
+});

--- a/recipe_app/static/js/nutrition-log-steps.js
+++ b/recipe_app/static/js/nutrition-log-steps.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.querySelector('form');
+  if (!form) return;
+  // Placeholder for future step logging enhancements
+});

--- a/recipe_app/static/js/nutrition-log-water.js
+++ b/recipe_app/static/js/nutrition-log-water.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.querySelector('form');
+  if (!form) return;
+  // Placeholder for future water logging enhancements
+});

--- a/recipe_app/templates/nutrition/log_meal.html
+++ b/recipe_app/templates/nutrition/log_meal.html
@@ -20,7 +20,7 @@
     </div>
     <div class="mb-3">
       <label for="foods" class="form-label">Foods:</label>
-      <select name="food_ids" id="foods" multiple class="form-select">
+      <select name="food_ids" id="foods" multiple class="form-select" data-foods='{{ foods|tojson|safe }}'>
         {% for food in foods %}
         <option value="{{ food.id }}">{{ food.name }} ({{ food.brand }})</option>
         {% endfor %}
@@ -36,24 +36,8 @@
     <p>Fat: <span id="totalFat">0</span></p>
   </div>
 </div>
-<script>
-// JS to update meal totals when foods are selected
-const foodsData = {{ foods|tojson|safe }};
-document.getElementById('foods').addEventListener('change', function() {
-    let selected = Array.from(this.selectedOptions).map(opt => parseInt(opt.value));
-    let totals = {calories: 0, protein: 0, carbs: 0, fat: 0};
-    foodsData.forEach(food => {
-        if (selected.includes(food.id)) {
-            totals.calories += food.calories;
-            totals.protein += food.protein;
-            totals.carbs += food.carbs;
-            totals.fat += food.fat;
-        }
-    });
-    document.getElementById('totalCalories').textContent = totals.calories;
-    document.getElementById('totalProtein').textContent = totals.protein;
-    document.getElementById('totalCarbs').textContent = totals.carbs;
-    document.getElementById('totalFat').textContent = totals.fat;
-});
-</script>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/nutrition-log-meal.js') }}"></script>
 {% endblock %}

--- a/recipe_app/templates/nutrition/log_steps.html
+++ b/recipe_app/templates/nutrition/log_steps.html
@@ -20,3 +20,7 @@
   </div>
 </div>
 {% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/nutrition-log-steps.js') }}"></script>
+{% endblock %}

--- a/recipe_app/templates/nutrition/log_water.html
+++ b/recipe_app/templates/nutrition/log_water.html
@@ -20,3 +20,7 @@
   </div>
 </div>
 {% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/nutrition-log-water.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- move meal total calculations to `nutrition-log-meal.js` and attach after `DOMContentLoaded`
- load nutrition logging scripts using template `{% block scripts %}`
- add placeholder scripts for water and steps logging pages for consistency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7fca9c4848329bd783cd0cbfcb42b