### PR TITLE
Improve dark theme styling for interactive elements

### DIFF
--- a/recipe_app/static/scss/_variables.scss
+++ b/recipe_app/static/scss/_variables.scss
@@ -1,12 +1,22 @@
-
 :root {
   --bg-color: #f8f9fa;
   --text-color: #212529;
+  --link-color: #0d6efd;
+  --link-hover-color: #0a58ca;
+  --border-color: #e9ecef;
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --surface-color: #ffffff;
 }
 
 [data-theme="dark"] {
   --bg-color: #121212;
   --text-color: #f8f9fa;
+  --link-color: #4dabf7;
+  --link-hover-color: #82cfff;
+  --border-color: #333333;
+  --shadow-color: rgba(0, 0, 0, 0.5);
+  --surface-color: #1e1e1e;
+}
 
 // Color palette
 $primary-color: #8b0000;
@@ -56,3 +66,4 @@ $radius-lg: 20px;
   --dark-text: #{$dark-text};
   --light-text: #{$light-text};
 }
+

--- a/recipe_app/static/style.css
+++ b/recipe_app/static/style.css
@@ -4,11 +4,21 @@
 :root {
     --bg-color: #f8f9fa;
     --text-color: #212529;
+    --link-color: #0d6efd;
+    --link-hover-color: #0a58ca;
+    --border-color: #e9ecef;
+    --shadow-color: rgba(0, 0, 0, 0.1);
+    --surface-color: #ffffff;
 }
 
 [data-theme="dark"] {
     --bg-color: #121212;
     --text-color: #f8f9fa;
+    --link-color: #4dabf7;
+    --link-hover-color: #82cfff;
+    --border-color: #333333;
+    --shadow-color: rgba(0, 0, 0, 0.5);
+    --surface-color: #1e1e1e;
 }
 
 body {
@@ -61,6 +71,8 @@ body {
 
 .text-primary {
     color: var(--secondary-color) !important;
+}
+
 :root {
   --primary-color: #8b0000;
   --primary-light: #a83232;
@@ -259,4 +271,38 @@ html {
 
 .recipe-method {
     list-style: decimal;
+}
+
+[data-theme="dark"] .card,
+[data-theme="dark"] .modal-content,
+[data-theme="dark"] .form-control,
+[data-theme="dark"] .alert {
+    background-color: var(--surface-color);
+    color: var(--text-color);
+    border-color: var(--border-color);
+    box-shadow: 0 0.125rem 0.25rem var(--shadow-color);
+}
+
+[data-theme="dark"] .btn {
+    background-color: var(--secondary-dark);
+    border-color: var(--secondary-dark);
+    color: var(--text-color);
+    box-shadow: 0 0.125rem 0.25rem var(--shadow-color);
+}
+
+a {
+    color: var(--link-color);
+}
+
+a:hover {
+    color: var(--link-hover-color);
+}
+
+.card,
+.modal-content,
+.form-control,
+.alert,
+.btn {
+    border: 1px solid var(--border-color);
+    box-shadow: 0 0.125rem 0.25rem var(--shadow-color);
 }


### PR DESCRIPTION
## Summary
- Expand root theme variables and dark theme values for links, borders, surfaces, and shadows
- Style cards, buttons, modals, form inputs, alerts, and links for dark mode readability

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c80a4d7d2883298ec4f7fb3b96668a